### PR TITLE
Update macOS Code

### DIFF
--- a/cslol-tools/lib/lol/io/sys.cpp
+++ b/cslol-tools/lib/lol/io/sys.cpp
@@ -91,7 +91,17 @@ auto sys::file_munmap(void* data, std::size_t count) noexcept -> void {
 #    include <sys/param.h>
 #    include <sys/stat.h>
 #    include <unistd.h>
+#    include <sys/resource.h>
 #    define last_error() std::error_code((int)errno, std::system_category())
+
+static ResourceLimit {
+    ResourceLimit() {
+        rlimit resourceLimit;
+        getrlimit(RLIMIT_NOFILE, &resourceLimit);
+        resourceLimit.rlim_cur = resourceLimit.rlim_max;
+        setrlimit(RLIMIT_NOFILE, &resourceLimit);
+    }
+} resourceLimit_ = {};
 
 auto sys::file_open(std::filesystem::path const& path, bool write) noexcept -> Result<std::intptr_t> {
     if (write) {

--- a/cslol-tools/lib/lol/patcher/patcher_macos.cpp
+++ b/cslol-tools/lib/lol/patcher/patcher_macos.cpp
@@ -49,7 +49,7 @@ struct Context {
         }
     }
 
-    auto scan(lol::Process const& process) -> void {
+    auto scan(Process const& process) -> void {
         auto data = process.Dump();
         auto macho = MachO{};
         macho.parse_data((MachO::data_t)data.data(), data.size());
@@ -64,7 +64,7 @@ struct Context {
         }
     }
 
-    auto patch(lol::Process const& process) -> void {
+    auto patch(Process const& process) -> void {
         auto payload = Payload{};
         memcpy(payload.prefix, prefix.c_str(), prefix.size() + 1);
         payload.fopen_org_ptr = process.Rebase(off_fopen_org);
@@ -109,10 +109,10 @@ auto patcher::run(std::function<bool(Message, char const*)> update,
         if (!update(M_FOUND, "")) return;
 
         if (!update(M_SCAN, "")) return;
-        impl_->scan(*process);
+        ctx.scan(*process);
 
         if (!update(M_PATCH, "")) return;
-        impl_->patch(*process, prefix);
+        ctx.patch(*process);
 
         for (std::uint32_t timeout = 3 * 60 * 60 * 1000; timeout; timeout -= 250) {
             if (!update(M_WAIT_EXIT, "")) return;

--- a/cslol-tools/lib/lol/patcher/utility/process.hpp
+++ b/cslol-tools/lib/lol/patcher/utility/process.hpp
@@ -46,6 +46,7 @@ namespace lol::patcher {
         mutable PtrStorage base_ = {};
         mutable uint32_t checksum_ = {};
         mutable std::filesystem::path path_ = {};
+        mutable uint32_t pid_ = {};
 
     public:
         Process() noexcept;

--- a/src/CSLOLToolsImpl.cpp
+++ b/src/CSLOLToolsImpl.cpp
@@ -241,7 +241,7 @@ void CSLOLToolsImpl::changeLeaguePath(QString newLeaguePath) {
         if (auto info = QFileInfo(newLeaguePath + "/League of Legends.exe"); info.exists()) {
             newLeaguePath = info.canonicalPath();
         }
-        if (auto info = QFileInfo(newLeaguePath + "/League of Legends.app"); info.exists()) {
+        if (auto info = QFileInfo(newLeaguePath + "/LeagueofLegends.app"); info.exists()) {
             newLeaguePath = info.canonicalPath();
         }
         if (game_ != newLeaguePath) {

--- a/src/CSLOLUtils.cpp
+++ b/src/CSLOLUtils.cpp
@@ -29,7 +29,7 @@ static QString try_game_path(QString path) {
     if (auto info = QFileInfo(path + "/League of Legends.exe"); info.exists()) {
         return info.canonicalPath();
     }
-    if (auto info = QFileInfo(path + "/League of Legends.app"); info.exists()) {
+    if (auto info = QFileInfo(path + "/LeagueofLegends.app"); info.exists()) {
         return info.canonicalPath();
     }
     return "";
@@ -38,6 +38,9 @@ static QString try_game_path(QString path) {
 QString CSLOLUtils::checkGamePath(QString pathRaw) {
     if (pathRaw.isEmpty()) {
         return pathRaw;
+    }
+    if (auto result = try_game_path(pathRaw + "/Contents/LoL/Game"); !result.isEmpty()) {
+        return result;
     }
     if (auto result = try_game_path(pathRaw); !result.isEmpty()) {
         return result;

--- a/src/qml/CSLOLDialogLoLPath.qml
+++ b/src/qml/CSLOLDialogLoLPath.qml
@@ -6,8 +6,8 @@ import Qt.labs.platform 1.0
 FileDialog {
     id: lolPathDialog
     visible: false
-    title: qsTr("Select League of Legends.exe")
+    title: qsTr("Select League of Legends Executable")
     fileMode: FileDialog.OpenFile
-    nameFilters: "League of Legends.exe (*.exe)"
+    nameFilters: ""
     folder: ""
 }


### PR DESCRIPTION
Some preliminary changes to bring macOS support back up to speed. Sudo is still needed for cslol-tools, so we will eventually have to implement that. Rosetta 2 (presumably) creates some issues on aarch64, but the code should work fine for x86-64.